### PR TITLE
Github API Integration

### DIFF
--- a/src/autofic_core/cli.py
+++ b/src/autofic_core/cli.py
@@ -1,9 +1,28 @@
 import click
+import argparse
+from autofic_core.github_handler import get_repo_files
 
 @click.command()
 @click.option('--repo', help='GitHub repository URL')
-def main(repo):
+@click.option('--silent', is_flag=True, help="결과 출력 없이 조용히 실행")
+def main(repo, silent):
     click.echo(f"Analyzing repo: {repo}")
+
+    parser = argparse.ArgumentParser(description="AutoFiC CLI")
+    parser.add_argument("--repo", type=str, required=True, help="GitHub 저장소 URL 입력")
+    parser.add_argument("--silent", action="store_true", help="결과 출력 없이 추출만 수행")  # ✅ 이 줄 추가!
+
+    args = parser.parse_args()
+
+    files = get_repo_files(args.repo, silent=args.silent)
+
+    # 파일 목록 출력 예시
+    if not files:
+        print("JS 파일을 찾지 못했습니다. 저장소 구조 또는 필터 조건을 확인하세요.")
+    elif not args.silent:
+        print(f"JS 파일 {len(files)}개를 찾았습니다:")
+        for file in files:
+            print(f"{file['path']} -> {file['download_url']}")
 
 if __name__ == '__main__':
     main()

--- a/src/autofic_core/github_handler.py
+++ b/src/autofic_core/github_handler.py
@@ -19,8 +19,6 @@ def get_repo_files(repo_url, file_extensions=(".js", ".mjs", ".jsx", ".ts"), sil
     token = os.getenv("GITHUB_TOKEN")
     if not token:
         raise ValueError("GITHUB_TOKEN이 .env에 없습니다.")
-    
-    print(f"[DEBUG] GITHUB_TOKEN: {repr(token)}")
 
     print("GitHub API 인증 시도 중")
 
@@ -45,9 +43,10 @@ def get_repo_files(repo_url, file_extensions=(".js", ".mjs", ".jsx", ".ts"), sil
     js_files = []
     contents = repo.get_contents("")
 
+    print("탐색 중입니다.")
+
     while contents:
         file_content = contents.pop(0)
-        print("탐색 중입니다.")
         if not silent:
             print(f"탐색 중: {file_content.path} ({file_content.type})")
         if file_content.type == "dir":
@@ -59,5 +58,7 @@ def get_repo_files(repo_url, file_extensions=(".js", ".mjs", ".jsx", ".ts"), sil
             })
             if not silent:
                 print(f"발견: {file_content.path}")
+                
+    print(f"JS 파일 {len(js_files)}개를 찾았습니다:")
 
     return js_files

--- a/src/autofic_core/github_handler.py
+++ b/src/autofic_core/github_handler.py
@@ -1,0 +1,63 @@
+# autofic_core/github_handler.py
+
+import os
+from github import Github
+from dotenv import load_dotenv
+from urllib.parse import urlparse
+
+load_dotenv()  # .env 파일에서 환경 변수 로드
+
+def parse_repo_url(repo_url):
+    """URL에서 사용자명/저장소명을 추출"""
+    path = urlparse(repo_url).path.strip("/")
+    owner, repo_name = path.split("/")[:2]
+    if repo_name.endswith(".git"):
+        repo_name = repo_name[:-4]
+    return owner, repo_name
+
+def get_repo_files(repo_url, file_extensions=(".js", ".mjs", ".jsx", ".ts"), silent=False):
+    token = os.getenv("GITHUB_TOKEN")
+    if not token:
+        raise ValueError("GITHUB_TOKEN이 .env에 없습니다.")
+    
+    print(f"[DEBUG] GITHUB_TOKEN: {repr(token)}")
+
+    print("GitHub API 인증 시도 중")
+
+    try:
+        g = Github(token)
+        user = g.get_user()
+        print(f"인증 성공! 연결된 계정: {user.login}")
+    except Exception as e:
+        print("GitHub 인증 실패:", e)
+        return []
+
+    try:
+        owner, repo_name = parse_repo_url(repo_url)
+        repo = g.get_repo(f"{owner}/{repo_name}")
+        print(f"저장소: {repo.full_name} (기본 브랜치: {repo.default_branch})")
+    except Exception as e:
+        print("저장소 불러오기 실패:", e)
+        return []
+    
+    target_exts = (".js", ".mjs", ".jsx", ".ts")
+
+    js_files = []
+    contents = repo.get_contents("")
+
+    while contents:
+        file_content = contents.pop(0)
+        print("탐색 중입니다.")
+        if not silent:
+            print(f"탐색 중: {file_content.path} ({file_content.type})")
+        if file_content.type == "dir":
+            contents.extend(repo.get_contents(file_content.path))
+        elif file_content.name.endswith(file_extensions) and file_content.download_url:
+            js_files.append({
+                "path": file_content.path,
+                "download_url": file_content.download_url
+            })
+            if not silent:
+                print(f"발견: {file_content.path}")
+
+    return js_files


### PR DESCRIPTION
Github API 연동 완료
+
연동 테스트를 위해 js 파일 개수 출력 코드가 포함되어 있습니다.

파일 개수 출력 시 탐색 중인 파일 목록을 모두 출력할 경우 실행 결과가 너무 길어져서 '--silent' 옵션 추가했습니다. Terminal에서 --silent 옵션 제외하고 입력할 시 탐색 파일 목록과 탐색 결과에 따른 소스 코드 다운로드 링크까지 제시됩니다.

테스트 시 사용한 레포는 https://github.com/FlipSideHR/FlyptoX.git 로 github에서 테스트용으로 찾은 규모가 크지 않은 레포입니다.


추가로 설치하여 사용한 라이브러리는 아래와 같습니다.
(노션에도 정리해두겠습니다.)
pip install PyGithub
pip install python-dotenv


<Terminal 입력>
python -m autofic_core.cli --repo https://github.com/FlipSideHR/FlyptoX.git --silent

<실행 결과>
Analyzing repo: https://github.com/FlipSideHR/FlyptoX.git
GitHub API 인증 시도 중
인증 성공! 연결된 계정: eunsol1530
저장소: FlipSideHR/FlyptoX (기본 브랜치: master)
JS 파일 54개를 찾았습니다.