### PR TITLE
Feature/llm-snippet-merging : Semgrep 라인 기준 병합 로직 구현

### DIFF
--- a/src/autofic_core/cli.py
+++ b/src/autofic_core/cli.py
@@ -7,7 +7,8 @@ from pathlib import Path
 from autofic_core.utils.progress_utils import create_progress
 from autofic_core.download.github_repo_handler import GitHubRepoHandler
 from autofic_core.sast.semgrep_runner import SemgrepRunner
-from autofic_core.sast.semgrep_preprocessor import SemgrepPreprocessor 
+from autofic_core.sast.semgrep_preprocessor import SemgrepPreprocessor
+from autofic_core.sast.semgrep_merger import merge_snippets_by_location
 from autofic_core.llm.prompt_generator import PromptGenerator
 from autofic_core.llm.llm_runner import LLMRunner, save_md_response
 from autofic_core.llm.response_parser import LLMResponseParser
@@ -82,11 +83,11 @@ def run_cli(repo, save_dir, sast, rule):
             base_dir=clone_path
         )
         
+        merged = merge_snippets_by_location(processed)
+        
         '''프롬프트 호출'''
-        prompts = PromptGenerator().from_semgrep_file (
-            semgrep_result_path,
-            base_dir=clone_path
-        )
+        prompts_generator = PromptGenerator()
+        prompts = prompts_generator.generate_prompts(merged)
         
         '''LLM 호출 및 응답 저장'''
         llm = LLMRunner()

--- a/src/autofic_core/llm/llm_runner.py
+++ b/src/autofic_core/llm/llm_runner.py
@@ -4,18 +4,21 @@ from pathlib import Path
 from openai import OpenAI
 from dotenv import load_dotenv
 from autofic_core.errors import LLMExecutionError
-from autofic_core.sast.semgrep_preprocessor import SemgrepSnippet
+from autofic_core.sast.semgrep_preprocessor import SemgrepPreprocessor, SemgrepSnippet
+from autofic_core.sast.semgrep_merger import merge_snippets_by_location
+from autofic_core.llm.prompt_generator import PromptGenerator
 
 load_dotenv()
 
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
 class LLMRunner:
     def __init__(self, model="gpt-4o"):
         self.model = model
 
     def run(self, prompt: str) -> str:
         try:
-            response = client.chat.completions.create(
+            response = client.chat.completions.create (
                 model=self.model,
                 messages=[
                     {"role": "system", "content": "You are a security code fixer."},
@@ -27,14 +30,14 @@ class LLMRunner:
         except Exception as e:
             click.echo(f"[LLM ERROR] 모델 요청 실패 - {e}")
             raise LLMExecutionError(str(e))
-        
+
+# LLM 응답 결과 .md 파일로 저장
 def save_md_response(content: str, snippet: SemgrepSnippet, output_dir: Path) -> str:
     output_dir.mkdir(parents=True, exist_ok=True)
 
     path = Path(snippet.path)
     parts = path.parts
 
-    # "artifacts", "downloaded_repo" 등 제거
     while parts and parts[0] in ("artifacts", "downloaded_repo"):
         parts = parts[1:]
 
@@ -42,12 +45,33 @@ def save_md_response(content: str, snippet: SemgrepSnippet, output_dir: Path) ->
     base_name = f"response_{flat_path}_{snippet.start_line}"
     output_path = output_dir / f"{base_name}.md"
 
-    counter = 2
-    while output_path.exists():
-        output_path = output_dir / f"{base_name}_{counter}.md"
-        counter += 1
-
     with open(output_path, "w", encoding="utf-8") as f:
         f.write(content)
 
     return str(output_path)
+
+
+def run_llm_for_semgrep_results(
+    semgrep_json_path: str,
+    output_dir: Path,
+    model: str = "gpt-4o",
+) -> None:
+
+    # semgrep 결과 JSON에서 스니펫 추출
+    raw_snippets = SemgrepPreprocessor.preprocess(semgrep_json_path)
+    # 위치 기준으로 스니펫 병합
+    merged_snippets = merge_snippets_by_location(raw_snippets)
+
+    # 프롬프트 생성
+    prompt_generator = PromptGenerator()
+    prompts = prompt_generator.generate_prompts(merged_snippets)
+
+    runner = LLMRunner(model=model)
+    
+    # 프롬프트별로 LLM 실행 및 응답 저장
+    for generated_prompt in prompts:
+        try:
+            response = runner.run(generated_prompt.prompt)
+            save_md_response(response, generated_prompt.snippet, output_dir)
+        except LLMExecutionError as e:
+            click.echo(f"[ERROR] LLM 처리 실패: {e}")

--- a/src/autofic_core/sast/semgrep_merger.py
+++ b/src/autofic_core/sast/semgrep_merger.py
@@ -1,0 +1,38 @@
+from collections import defaultdict
+from typing import List
+from autofic_core.sast.semgrep_preprocessor import SemgrepSnippet
+
+# 동일한 위치(파일, 시작/끝 라인)의 스니펫 병합
+def merge_snippets_by_location(snippets: List[SemgrepSnippet]) -> List[SemgrepSnippet]:
+    grouped = defaultdict(list)
+
+    # 경로, 시작 라인, 끝 라인 기준으로 그룹핑
+    for snippet in snippets:
+        key = (snippet.path, snippet.start_line, snippet.end_line)
+        grouped[key].append(snippet)
+
+    merged_snippets = []
+
+    # 각 그룹별로 하나의 스니펫으로 병합
+    for (_, start_line, end_line), group in grouped.items():
+        base = group[0]
+
+        merged_snippets.append(SemgrepSnippet(
+            input=base.input,
+            output="",
+            idx=base.idx, 
+            start_line=start_line,
+            end_line=end_line,
+            snippet="\n\n".join(s.snippet for s in group),
+            message=" | ".join(s.message for s in group),
+            vulnerability_class=list({vc for s in group for vc in s.vulnerability_class}),
+            cwe=list({c for s in group for c in s.cwe}),
+            severity=max(
+                (s.severity for s in group),
+                key=lambda x: ["INFO", "WARNING", "ERROR"].index(x.upper()) if x else -1
+            ),
+            references=list({r for s in group for r in s.references}),
+            path=base.path
+        ))
+
+    return merged_snippets


### PR DESCRIPTION
# Feature/llm-snippet-merging

### 📌 기능 개요
> Semgrep 결과에서 중복되거나 겹치는 라인 기준, 스니펫을 병합하여 LLM에 전달할 프롬프트의 효율성과 일관성을 높입니다.
* 병합된 스니펫을 바탕으로 LLM 호출 및 응답 저장 기능에 적용


### 🧩 클래스 및 함수 설명
* Semgrep 스니펫 리스트를 라인 단위 위치 기준으로 그룹핑 및 병합 처리
* LLM 호출 및 응답 저장 모듈에서 병합 스니펫을 활용하도록 리팩토링


### 🧪 테스트 방법 및 결과
* [LLM 응답 비교 결과](https://dapper-fortnight-cc0.notion.site/LLM-21d8cb2fcb6f8018b63efa015fb5d9bd)


### 📎기타 참고 사항
* 병합 기준인 (path, start_line, end_line)은 필요 시 확장 가능합니다.