### PR TITLE
Feature/dashboard : Add dashboard pages 구축

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -1,0 +1,44 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Update dashboard pages
+
+on:
+  pull_request:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    if: github.ref == 'refs/heads/dev'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Generate dashboard_data.json
+        run: |
+          python src/autofic_core/pages/log_to_dashboard.py
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'src/autofic_core/pages'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/src/autofic_core/pages/dashboard.html
+++ b/src/autofic_core/pages/dashboard.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <title>Autofic Dashboard</title>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 20px; }
+    .card { background: #f7f7f7; padding: 15px; margin: 10px; border-radius: 5px; display: inline-block; width: 220px; vertical-align: top; }
+    h2 { margin-top: 0; }
+  </style>
+</head>
+<body>
+  <h1>Autofic Dashboard</h1>
+
+  <div class="card">
+    <h2>📈 PR 생성 수</h2>
+    <p>전체: <span id="pr-total">--</span></p>
+    <p>일일: <span id="pr-daily">--</span></p>
+    <p>주간: <span id="pr-weekly">--</span></p>
+  </div>
+
+  <h2>레포지토리 정보</h2>
+  <ul id="repo-list"></ul>
+
+  <script>
+    fetch('dashboard_data.json')
+      .then(res => res.json())
+      .then(data => {
+        // PR 생성 수
+        document.getElementById('pr-total').textContent = data.prCount.total;
+        document.getElementById('pr-daily').textContent = data.prCount.daily;
+        document.getElementById('pr-weekly').textContent = data.prCount.weekly;
+
+        // 레포지토리 정보
+        const repoList = document.getElementById('repo-list');
+        data.repos.forEach(r => {
+          repoList.innerHTML += `<li><a href="${r.url}" target="_blank">${r.name}</a> – 취약점: ${r.vulnerabilities} / 수정: ${r.fixes}</li>`;
+        });
+
+      })
+      .catch(err => console.error('Error loading dashboard data:', err));
+  </script>
+</body>
+</html>

--- a/src/autofic_core/pages/log_to_dashboard.py
+++ b/src/autofic_core/pages/log_to_dashboard.py
@@ -1,0 +1,48 @@
+import json
+from datetime import datetime, timedelta
+import os
+
+class DashboardBuilder:
+    def __init__(self, log_path=None, dashboard_path=None):
+        base_dir = os.path.dirname(__file__)
+        self.log_path = os.path.abspath(log_path or os.path.join(base_dir, 'log.json'))
+        self.dashboard_path = os.path.abspath(dashboard_path or os.path.join(base_dir, 'dashboard_data.json'))
+
+    def load_log_data(self):
+        with open(self.log_path, encoding="utf-8") as f:
+            return json.load(f)
+
+    def build_dashboard_data(self, logs):
+        today = datetime.now().date()
+        week_ago = today - timedelta(days=7)
+
+        pr_daily = sum(1 for p in logs.get("prs", []) if p["date"] == str(today))
+        pr_weekly = sum(1 for p in logs.get("prs", []) if datetime.fromisoformat(p["date"]).date() >= week_ago)
+        pr_total = len(logs.get("prs", []))
+
+        return {
+            "prCount": {
+                "total": pr_total,
+                "daily": pr_daily,
+                "weekly": pr_weekly
+            },
+            "repos": logs.get("repos", [])
+        }
+
+    def save_dashboard_data(self, dashboard_data):
+        with open(self.dashboard_path, "w", encoding="utf-8") as f:
+            json.dump(dashboard_data, f, ensure_ascii=False, indent=2)
+        print(f"dashboard_data.json 생성 완료")
+
+    def run(self):
+        try:
+            logs = self.load_log_data()
+            dashboard_data = self.build_dashboard_data(logs)
+            self.save_dashboard_data(dashboard_data)
+        except Exception as e:
+            print(f"[ERROR] Dashboard generation failed: {e}")
+
+if __name__ == "__main__":
+    builder = DashboardBuilder()
+    builder.run()
+

--- a/src/autofic_core/pages/log_writer.py
+++ b/src/autofic_core/pages/log_writer.py
@@ -1,0 +1,48 @@
+import json
+import os
+
+class LogManager:
+    def __init__(self, log_path=None):
+        if log_path:
+            self.log_path = os.path.abspath(log_path)
+        else:
+            self.log_path = os.path.join(os.path.dirname(__file__), 'log.json')
+
+    def load(self):
+        if os.path.exists(self.log_path):
+            with open(self.log_path, "r", encoding="utf-8") as f:
+                try:
+                    logs = json.load(f)
+                except json.JSONDecodeError:
+                    logs = {}
+        else:
+            logs = {}
+
+        logs.setdefault("prs", [])
+        logs.setdefault("repos", [])
+        return logs
+
+    def save(self, logs):
+        with open(self.log_path, "w", encoding="utf-8") as f:
+            json.dump(logs, f, ensure_ascii=False, indent=2)
+        print("log.json 업데이트 완료")
+
+    def add_pr_log(self, date, repo, pr_number):
+        logs = self.load()
+        logs["prs"] = [p for p in logs["prs"] if not (p["pr_number"] == pr_number and p["repo"] == repo)]
+        logs["prs"].append({
+            "date": date,
+            "repo": repo,
+            "pr_number": pr_number
+        })
+        self.save(logs)
+
+    def add_repo_log(self, name, url, vulnerabilities):
+        logs = self.load()
+        logs["repos"] = [r for r in logs["repos"] if r["name"] != name]
+        logs["repos"].append({
+            "name": name,
+            "url": url,
+            "vulnerabilities": vulnerabilities
+        })
+        self.save(logs)

--- a/src/autofic_core/pr_auto/pr_main.py
+++ b/src/autofic_core/pr_auto/pr_main.py
@@ -19,6 +19,7 @@ import os
 from .create_yml import AboutYml
 from .env_encrypt import EnvEncrypy
 from .pr_procedure import PRProcedure
+from autofic_core.pages.log_writer import LogManager
 
 class BranchPRAutomation:
     """
@@ -122,7 +123,13 @@ class BranchPRAutomation:
         # Chapter 8,9
         pr_procedure.generate_pr()
         self.result["generate_pr"] = True
-        pr_procedure.create_pr()
+        pr_number = pr_procedure.create_pr()
         self.result["create_upstream_pr"] = True
+        # for log
+        log_manager = LogManager()
+        if pr_number:
+            pr_creation_data, repo_status_data = pr_procedure.generate_log_data(pr_number)
+            log_manager.add_pr_log(**pr_creation_data)
+            log_manager.add_repo_log(**repo_status_data)
         # END
         return self.result


### PR DESCRIPTION
✅ 파일 설명 (src/autofic_core/pages/)
1. log_writer.py 
 - log 정보 (현재는 PR 생성 시 번호(수), Repo 정보 등) 기록 기능
 
2. log_to_dashboard.py
 - log.json → dashboard_data.json 변환
 - PR 생성 수(일일/주간/전체) 카운트 처리

3. dashboard.html
 - dashboard_data.json을 fetch해서 대시보드 페이지 렌더링
 - 현재 PR 생성 개수, Repo 정보 표시
 
4. GitHub Actions (dashboard.yml)
  - PR 시 → log_to_dashboard.py 자동 실행
  - 생성된 dashboard_data.json 포함 → Pages로 배포
  
✅ 추가 설명
 - PR 생성 성공 할 때마다 log 얻으려고 pr_auto 기능 코드들에서 log 수집
 - 구현이 이상하다면 말해주세요!
 - 이후 html 개선 (테마 적용 방안 생각 중), 추가 지표 수집 예정 