### PR TITLE
Refactor/cli: RepositoryManager 에러처리

### DIFF
--- a/src/autofic_core/cli.py
+++ b/src/autofic_core/cli.py
@@ -43,14 +43,12 @@ class RepositoryManager:
         self.repo_url = repo_url
         self.save_dir = save_dir
         self.clone_path = None
-        #try:
-        self.handler = GitHubRepoHandler(repo_url=self.repo_url)
-        #except GitHubTokenMissingError as e:
-        #    console.print(f"[ ERROR ] GitHub token is missing: {e}", style="red")
-        #    raise
-        #except RepoURLFormatError as e:
-            #console.print(f"[ ERROR ] Invalid repository URL: {e}", style="red")
-            #raise
+        try:
+            self.handler = GitHubRepoHandler(repo_url=self.repo_url)
+        except GitHubTokenMissingError as e:
+            raise
+        except RepoURLFormatError as e:
+            raise
 
     def clone(self):
         print_divider("Repository Cloning Stage")
@@ -70,10 +68,7 @@ class RepositoryManager:
             sys.exit(1)
 
         except RepoAccessError as e:
-            console.print(f"[ ERROR ] Cannot access repository: {e}", style="red")
-            #raise
-            sys.exit(1)
-
+            raise
 
         except (PermissionError, OSError) as e:
             console.print(f"[ ERROR ] Access denied while cloning repository: {e}", style="red")
@@ -572,8 +567,15 @@ def main(explain, repo, save_dir, sast, llm, llm_retry, patch, pr):
             log_manager.add_pr_log(pr_log_data)
             log_manager.add_repo_status(repo_data)
 
+    #except Exception as e:
+    #        console.print(f"[ ERROR ] {e}", style="red")
+
+    except AutoficError as e:
+        console.print(str(e), style="red")
+        sys.exit(1)
     except Exception as e:
-            console.print(f"[ ERROR ] {e}", style="red")
+        console.print(f"[ UNEXPECTED ERROR ] {str(e)}", style="red")
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()

--- a/src/autofic_core/cli.py
+++ b/src/autofic_core/cli.py
@@ -43,14 +43,14 @@ class RepositoryManager:
         self.repo_url = repo_url
         self.save_dir = save_dir
         self.clone_path = None
-        try:
-            self.handler = GitHubRepoHandler(repo_url=self.repo_url)
-        except GitHubTokenMissingError as e:
-            console.print(f"[ ERROR ] GitHub token is missing: {e}", style="red")
-            raise
-        except RepoURLFormatError as e:
-            console.print(f"[ ERROR ] Invalid repository URL: {e}", style="red")
-            raise
+        #try:
+        self.handler = GitHubRepoHandler(repo_url=self.repo_url)
+        #except GitHubTokenMissingError as e:
+        #    console.print(f"[ ERROR ] GitHub token is missing: {e}", style="red")
+        #    raise
+        #except RepoURLFormatError as e:
+            #console.print(f"[ ERROR ] Invalid repository URL: {e}", style="red")
+            #raise
 
     def clone(self):
         print_divider("Repository Cloning Stage")
@@ -61,23 +61,25 @@ class RepositoryManager:
                 self.handler.fork()
                 time.sleep(1)
                 console.print("\n[ SUCCESS ] Fork completed\n", style="green")
-        except ForkFailedError as e:
-            console.print(f"[ ERROR ] Failed to fork repository: {e}", style="red")
-            raise
 
-        try:
             self.clone_path = Path(self.handler.clone_repo(save_dir=str(self.save_dir), use_forked=self.handler.needs_fork))
             console.print(f"\n[ SUCCESS ] Repository cloned successfully: {self.clone_path}\n", style="green")
+
+        except ForkFailedError as e:
+            #raise
+            sys.exit(1)
+
         except RepoAccessError as e:
             console.print(f"[ ERROR ] Cannot access repository: {e}", style="red")
-            raise
+            #raise
+            sys.exit(1)
+
+
         except (PermissionError, OSError) as e:
             console.print(f"[ ERROR ] Access denied while cloning repository: {e}", style="red")
-            console.print("💡 Close any editors or terminals using the directory and try again.", style="yellow")
-            raise
-        except Exception as e:
-            console.print(f"[ ERROR ] Unexpected error during cloning: {e}", style="red")
-            raise
+            console.print("Close any editors or terminals using the directory and try again.", style="yellow")
+            #raise
+            sys.exit(1)
 
 class SemgrepHandler:
     def __init__(self, repo_path: Path, save_dir: Path):

--- a/src/autofic_core/errors.py
+++ b/src/autofic_core/errors.py
@@ -6,19 +6,24 @@ class AutoficError(Exception):
 
 class GitHubTokenMissingError(AutoficError):
     def __init__(self):
-        super().__init__(f"GitHub token is missing: GITHUB_TOKEN is not set in the environment.")
+        message = f"GitHub token is missing: GITHUB_TOKEN is not set in the environment."
+        super().__init__(message)
 
 class RepoURLFormatError(AutoficError):
     def __init__(self, repo_url):
-        super().__init__(f"Invalid GitHub repository URL format: {repo_url}")
-
-class RepoAccessError(AutoficError):
-    def __init__(self, message="Failed to access the repository."):
+        message = f"Invalid GitHub repository URL format: {repo_url}"
         super().__init__(message)
 
+class RepoAccessError(AutoficError):
+    def __init__(self, original_error):
+        message = f"Cannot access repository: {original_error}"
+        super().__init__(message)
+        self.original_error = original_error
+
 class ForkFailedError(AutoficError):
-    def __init__(self, status_code, message):
-        super().__init__(f"Failed to fork repository (HTTP {status_code}) - {message}")
+    def __init__(self, status_code, msg):
+        message = f"Failed to fork repository (HTTP {status_code}) - {msg}"
+        super().__init__(message)
 
 # downloader.py
 

--- a/src/autofic_core/errors.py
+++ b/src/autofic_core/errors.py
@@ -6,17 +6,17 @@ class AutoficError(Exception):
 
 class GitHubTokenMissingError(AutoficError):
     def __init__(self):
-        super().__init__("GITHUB_TOKEN is not set in the environment.")
+        super().__init__(f"GitHub token is missing: GITHUB_TOKEN is not set in the environment.")
 
 class RepoURLFormatError(AutoficError):
     def __init__(self, repo_url):
         super().__init__(f"Invalid GitHub repository URL format: {repo_url}")
 
 class RepoAccessError(AutoficError):
-    def __init__(self):
-        super().__init__("Failed to access the repository.")
+    def __init__(self, message="Failed to access the repository."):
+        super().__init__(message)
 
-class ForkFailedError(RepoAccessError):
+class ForkFailedError(AutoficError):
     def __init__(self, status_code, message):
         super().__init__(f"Failed to fork repository (HTTP {status_code}) - {message}")
 


### PR DESCRIPTION
github_repo_handler.py,
cli.py,
errors.py 에러처리 관련 코드 수정했습니다.



**1. github 토큰 없음 에러 (토큰 환경변수 제거 후 테스트)** 

class GitHubTokenMissingError(AutoficError):
    def __init__(self):
        message = f"GitHub token is missing: GITHUB_TOKEN is not set in the environment."
        super().__init__(message)


**2. 유효하지 않은 url 에러 (링크에 오탈자 넣어서 테스트)** 

class RepoURLFormatError(AutoficError):
    def __init__(self, repo_url):
        message = f"Invalid GitHub repository URL format: {repo_url}"
        super().__init__(message)

**3. 레포지터리 접근 에러 (삭제된 레포 url로 테스트)** 

class RepoAccessError(AutoficError):
    def __init__(self, original_error):
        message = f"Cannot access repository: {original_error}"
        super().__init__(message)
        self.original_error = original_error

**4. 그 외의 이유인 포크 실패 에러 (포크가 막혀있는 레포로 테스트해볼 수 있을 것 같은데 못찾아서 ForkFailedError는 위의 에러들 정의 수정하면서밖에 확인을 못했습니다) ** 

class ForkFailedError(AutoficError):
    def __init__(self, status_code, msg):
        message = f"Failed to fork repository (HTTP {status_code}) - {msg}"
        super().__init__(message)


추가로 PermissionError는 사용자 지정 파일 저장 경로/repo 디렉토리의 권한을 -w로 바꿔서 테스트해봤습니다.

cli.py에서는 

    except AutoficError as e:
        console.print(str(e), style="red")
        sys.exit(1)
    except Exception as e:
        console.print(f"[ UNEXPECTED ERROR ] {str(e)}", style="red")
        sys.exit(1)
        
와 같이 에러 중복처리 방지했습니다.

github_repo_handler.py에서는 repoaccesserror 시 traceback 방지를 위해 

        try:
            subprocess.run(['git', 'clone', clone_url, repo_path], check=True,
                            stdout=subprocess.PIPE,
                            stderr=subprocess.PIPE,
                            text=True)
        except subprocess.CalledProcessError as e:
            raise RepoAccessError(e)
            
와 같이 수정했습니다.


