### PR TITLE
Add: tracking llm token usage

### DIFF
--- a/src/autofic_core/llm/llm_runner.py
+++ b/src/autofic_core/llm/llm_runner.py
@@ -50,6 +50,17 @@ class LLMRunner:
                 ],
                 temperature=0.3
             )
+
+            #여기서 토큰 사용량 로깅
+            usage = getattr(response, "usage", None)
+            if usage is not None:
+                print(
+                    f"[TOKENS] prompt={usage.prompt_tokens}, "
+                    f"completion={usage.completion_tokens}, "
+                    f"total={usage.total_tokens}",
+                )
+                print()
+
             return response.choices[0].message.content.strip()
         except Exception as e:
             raise LLMExecutionError(str(e))


### PR DESCRIPTION
llm_runner.py 파일 내부 LLMRunner 클래스의 run 메서드에 토큰 사용량 출력 코드 추가했습니다.
아래와 같이 출력됩니다.


━━━━━━━━━━━━━━━━━━━━━━━━━ ◆ [ LLM Response Generation Stage ] ◆ ━━━━━━━━━━━━━━━━━━━━━━━━━


[INFO] Using CUSTOM_CONTEXT.xml for enhanced prompts

**[TOKENS] prompt=1655, completion=1103, total=2758**

  Generating LLM responses...  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100%
                                                                                           
[ SUCCESS ] LLM responses saved → /Users/kim-eunsol/test-paper/10/semgrep/llm
